### PR TITLE
feat: add note duplication command and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,21 @@ pinkmess note generate-metadata --key summary
 pinkmess note generate-metadata --path ~/notes/20230815123456.md --key tags
 ```
 
+### Duplicate Note
+```bash
+pinkmess note duplicate [--path PATH]
+```
+Creates a copy of the specified note (or last created note) with a new timestamp-based filename in the current collection.
+
+Example:
+```bash
+# Duplicate the last created note
+pinkmess note duplicate
+
+# Duplicate a specific note
+pinkmess note duplicate --path ~/notes/20230815123456.md
+```
+
 ### Show Last Created Note
 ```bash
 pinkmess note last

--- a/src/pinkmess/note.py
+++ b/src/pinkmess/note.py
@@ -54,9 +54,7 @@ class Note(BaseModel):
         """
         Saves the note content and metadata.
         """
-        if self.content is None:
-            raise ValueError("Note content is empty.")
         if self.metadata is None:
-            self.path.write_text(self.content)
+            self.path.write_text(self.content or "")
         else:
             self.path.write_text(frontmatter.dumps(self.metadata))


### PR DESCRIPTION
This pull request introduces a new feature for duplicating notes and includes several code simplifications. The most important changes are the addition of the `NoteDuplicateCommand` class and the corresponding CLI command, as well as some minor code cleanups.

New feature:

* [`src/pinkmess/cli/note.py`](diffhunk://#diff-38f284dd87fb973d95c1ef45f394418952242d323e3095d1785021724b1f5263R122-R154): Added the `NoteDuplicateCommand` class to handle note duplication. This class includes logic for duplicating a note, either the last created note or a specific note provided by the user.
* [`src/pinkmess/cli/note.py`](diffhunk://#diff-38f284dd87fb973d95c1ef45f394418952242d323e3095d1785021724b1f5263R164): Updated the `NoteCommands` class to include the new `duplicate` subcommand, allowing users to duplicate notes via the CLI.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R163): Added documentation for the new `duplicate` command, including usage examples.

Code simplifications:

* [`src/pinkmess/cli/note.py`](diffhunk://#diff-38f284dd87fb973d95c1ef45f394418952242d323e3095d1785021724b1f5263L30-R30): Simplified the assignment of `last_created_note` by removing unnecessary line breaks.
* [`src/pinkmess/cli/note.py`](diffhunk://#diff-38f284dd87fb973d95c1ef45f394418952242d323e3095d1785021724b1f5263L71-R69): Simplified the `run_sync` method call by removing unnecessary line breaks.
* [`src/pinkmess/note.py`](diffhunk://#diff-69a0306a42e26b8cacd09e9ff7e78f7f47d744ae3e4938ad60fb8695d1d71336L57-R58): Simplified the `save` method by removing a redundant check for `self.content` and ensuring that an empty string is written if `self.content` is `None`.

Closes #8 