### PR TITLE
feat: add command to open collections and update last created note

### DIFF
--- a/src/pinkmess/cli/collection.py
+++ b/src/pinkmess/cli/collection.py
@@ -1,3 +1,4 @@
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -129,6 +130,30 @@ class CollectionRemoveCommand(BaseModel):
             print(f"Collection '{self.name}' not found.")
 
 
+class CollectionOpenCommand(BaseModel):
+    """
+    Opens a collection.
+    """
+
+    name: str | None = None
+    """The name of the collection. If not provided, the current collection is opened."""
+
+    def cli_cmd(self) -> None:
+        collection = (
+            settings.get_collection_by_name(self.name) if self.name is not None else settings.current_collection
+        )
+
+        if collection is None:
+            print("No current collection found.")
+            return
+
+        print(f"Opening collection '{collection.name}' in {settings.editor}...")
+        subprocess.run([settings.editor, collection.path.as_posix()])
+        print(f"Collection '{collection.name}' successfully opened.")
+        print("Updating collection last created note...")
+        settings.collections[collection.index].update_last_created_note()
+
+
 class CollectionStatsCommand(BaseModel):
     """
     Shows the statistics of a collection.
@@ -152,28 +177,14 @@ class CollectionCommands(BaseModel):
     """
 
     create: CliSubCommand[CollectionCreateCommand]
-    """Creates a new collection."""
-
     set: CliSubCommand[CollectionSetCommand]
-    """Sets the current collection."""
-
     current: CliSubCommand[CollectionShowCurrentCommand]
-    """Shows the current collection."""
-
     list: CliSubCommand[CollectionListCommand]
-    """Lists the collections."""
-
     ls: CliSubCommand[CollectionListCommand]
-    """Alias for 'list'."""
-
     remove: CliSubCommand[CollectionRemoveCommand]
-    """Removes a collection."""
-
     rm: CliSubCommand[CollectionRemoveCommand]
-    """Alias for 'remove'."""
-
     stats: CliSubCommand[CollectionStatsCommand]
-    """Shows the statistics of a collection."""
+    open: CliSubCommand[CollectionOpenCommand]
 
     def cli_cmd(self) -> None:
         CliApp.run_subcommand(self)

--- a/src/pinkmess/collection.py
+++ b/src/pinkmess/collection.py
@@ -63,15 +63,9 @@ class Collection(BaseModel):
         Sets the last created note.
         """
         if self.last_created_note is None:
-            existing_notes = sorted(self.path.glob("*.md"), reverse=True)
+            self.update_last_created_note()
 
-            if existing_notes:
-                self.last_created_note = existing_notes[0]
-
-        if (
-            self.last_created_note is not None
-            and not self.last_created_note.is_relative_to(self.path)
-        ):
+        if self.last_created_note is not None and not self.last_created_note.is_relative_to(self.path):
             raise ValueError("Last created note is not in the collection.")
 
         return self
@@ -91,3 +85,11 @@ class Collection(BaseModel):
         if path is None:
             return None
         return path.resolve().absolute().as_posix()
+
+    def update_last_created_note(self) -> None:
+        """
+        Updates the last created note.
+        """
+        existing_notes = sorted(self.path.glob("*.md"), reverse=True)
+        if existing_notes:
+            self.last_created_note = existing_notes[0]

--- a/src/pinkmess/config.py
+++ b/src/pinkmess/config.py
@@ -79,11 +79,16 @@ class Settings(BaseSettings):
             return self.default_llm_settings
         return self.current_collection.llm_settings
 
+    def get_collection_by_name(self, name: str) -> Collection | None:
+        """Returns a collection by name."""
+        for collection in self.collections:
+            if collection.name == name:
+                return collection
+        return None
+
     def save(self) -> None:
         """Saves the settings."""
-        DEFAULT_CONFIG_PATH.write_text(
-            rtoml.dumps(self.model_dump(), pretty=True, none_value=None)
-        )
+        DEFAULT_CONFIG_PATH.write_text(rtoml.dumps(self.model_dump(), pretty=True, none_value=None))
 
 
 settings = Settings()


### PR DESCRIPTION
This pull request introduces a new command to open a collection, refactors how the last created note is updated, and adds a method to retrieve a collection by name. The most important changes are detailed below:

### New Command Addition:
* Added `CollectionOpenCommand` class to open a collection and update the last created note. (`src/pinkmess/cli/collection.py` [src/pinkmess/cli/collection.pyR133-R156](diffhunk://#diff-9e5a83f4a91526370e224c22e31d1c7c43f12f47f9e92ccb88c7d05910fa5bceR133-R156))
* Integrated the new `open` subcommand into the `CollectionCommands` class. (`src/pinkmess/cli/collection.py` [src/pinkmess/cli/collection.pyL155-R187](diffhunk://#diff-9e5a83f4a91526370e224c22e31d1c7c43f12f47f9e92ccb88c7d05910fa5bceL155-R187))

### Refactoring:
* Refactored `set_last_created_note` to use the new `update_last_created_note` method. (`src/pinkmess/collection.py` [src/pinkmess/collection.pyL66-R68](diffhunk://#diff-5eef9bcc4fb106236f01e93ca922d3e6f100bd83922038d8c5bbeb5c8c504ce9L66-R68))
* Added the `update_last_created_note` method to update the last created note in a collection. (`src/pinkmess/collection.py` [src/pinkmess/collection.pyR88-R95](diffhunk://#diff-5eef9bcc4fb106236f01e93ca922d3e6f100bd83922038d8c5bbeb5c8c504ce9R88-R95))

### Utility Method:
* Added `get_collection_by_name` method to retrieve a collection by its name. (`src/pinkmess/config.py` [src/pinkmess/config.pyR82-R91](diffhunk://#diff-80febccfdb4165426a29372bc56e4ca4c3e74dc21334b8c15b8d96ec2f7131f3R82-R91))

These changes enhance the functionality and maintainability of the codebase by introducing a new command, improving existing methods, and adding utility functions.

Closes #12 