### PR TITLE
docs: add usage instructions for opening collections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ Example:
 pinkmess collection remove personal
 ```
 
+### Open Collection
+```bash
+pinkmess collection open [--name NAME]
+```
+Opens the specified collection (or current collection if no name provided) in your configured editor.
+
+Example:
+```bash
+# Open current collection
+pinkmess collection open
+
+# Open a specific collection
+pinkmess collection open --name personal
+```
+
 ### Show Collection Stats
 ```bash
 pinkmess collection stats


### PR DESCRIPTION
This pull request includes an update to the `README.md` file to add a new section on how to open a collection using the `pinkmess` CLI tool. The most important change is the addition of the "Open Collection" section, which provides usage instructions and examples.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R114-R128): Added a new section "Open Collection" with instructions on how to use the `pinkmess collection open` command, including examples for opening the current collection and a specific collection by name.

Closes #14 