### PR TITLE
feat: display current collection in the collection list

### DIFF
--- a/src/pinkmess/cli/collection.py
+++ b/src/pinkmess/cli/collection.py
@@ -104,7 +104,9 @@ class CollectionListCommand(BaseModel):
 
         print("Collections:")
         for collection in settings.collections:
-            print(f" -> {collection.name}: {collection.path.absolute()}")
+            is_current = collection.index == settings.current_collection_index
+            is_current_str = "(current)" if is_current else ""
+            print(f" -> {collection.name}: {collection.path.absolute()} {is_current_str}")
 
 
 class CollectionRemoveCommand(BaseModel):
@@ -161,6 +163,11 @@ class CollectionStatsCommand(BaseModel):
 
     def cli_cmd(self) -> None:
         collection = settings.current_collection
+
+        if collection is None:
+            print("No current collection found.")
+            return
+
         n_notes = len(list(collection.path.glob("*.md")))
         created_at = datetime.fromtimestamp(collection.path.stat().st_ctime)
         updated_at = datetime.fromtimestamp(collection.path.stat().st_mtime)


### PR DESCRIPTION
This pull request includes enhancements to the `cli_cmd` methods in the `Collection` commands within the `src/pinkmess/cli/collection.py` file. The changes improve the user experience by providing additional context and handling edge cases.

Enhancements to `cli_cmd` methods:

* [`src/pinkmess/cli/collection.py`](diffhunk://#diff-9e5a83f4a91526370e224c22e31d1c7c43f12f47f9e92ccb88c7d05910fa5bceL107-R109): In the `cli_cmd` method of the `Collection` class, added logic to indicate the current collection in the printed output.
* [`src/pinkmess/cli/collection.py`](diffhunk://#diff-9e5a83f4a91526370e224c22e31d1c7c43f12f47f9e92ccb88c7d05910fa5bceR166-R170): In the `cli_cmd` method of the `CollectionStatsCommand` class, added a check to handle cases where no current collection is found, with a corresponding message.

Closes #6 